### PR TITLE
Camera fix: init.rc script is modified to start surfaceflinger and TvoutService_C services at startup on SGS2.

### DIFF
--- a/init.rc
+++ b/init.rc
@@ -587,7 +587,7 @@ on boot
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_setspeed 1000000
 
 # Set this property so surfaceflinger is not started by system_init
-    setprop system_init.startsurfaceflinger 0
+    #setprop system_init.startsurfaceflinger 0
 
     class_start core
     class_start main
@@ -925,4 +925,6 @@ on property:sysimg.android=1
 
 on property:sysimg.gonk=1
 	start servicemanager-g
+	start surfaceflinger
+	start TvoutService_C
 	class_start b2g


### PR DESCRIPTION
They are needed (cause one is dependant on the other) by the camera in order to work.
Surfaceflinger seems to not create any conflict with B2G (it is probably not being used at all, just a dependency for some Android specific stuff).
Could @michaelwu or @dhylands review this changes? :)
Thanks!
